### PR TITLE
Use draft releases, don't delete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
               -r ${CIRCLE_PROJECT_REPONAME} \
               -n "${CIRCLE_TAG#v}" \
               -b "$(</tmp/release.txt)" \
-              -delete \
+              -draft \
               ${CIRCLE_TAG} artifacts/
 
 workflows:


### PR DESCRIPTION
Automated release notes are not perfect, this will create draft releases instead and avoid deleting an existing release.
We manually update and publish releases.